### PR TITLE
Fail when configuration is needed instead of causing obscure issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ Edit `project.mk` to customize most things specific to the project (like the gam
 
 Everything in the `src` folder is the source, and can be freely modified however you want. The basic structure in place should hint you at how things are organized. If you want to create a new "module", you simply need to drop a `.asm` file in the `src` directory, name does not matter. All `.asm` files in that root directory will be individually compiled by RGBASM.
 
-There is "basic" code in place, but some things need your manual intervention. Look for `ld b, b` instructions, there will be comments indicating what to put.
+There is "basic" code in place, but some things need your manual intervention. Things requiring manual intervention will print an error message describing what needs to be changed, and a line number.
 
 The file at `src/res/build_date.asm` is compiled individually to include a build date in your ROM. Always comes in handy, and displayed in the bundled error handler.
 
 If you want to add resources, I recommend using the `src/res` folder. Add rules in the Makefile; there are several examples.
+
+It is recommended that the start of your code be in `src/intro.asm`.
 
 ## Compiling
 

--- a/src/header.asm
+++ b/src/header.asm
@@ -51,9 +51,9 @@ Reset::
 	dec b
 	jr nz, .copyOAMDMA
 
-	; You will want to init palettes here
+	FAIL "Edit to set palettes here"
 	; CGB palettes maybe, DMG ones always
-	ld b, b
+
 	; You will also need to reset your handlers' variables below
 	; I recommend reading through, understanding, and customizing this file
 	; in its entirety anyways. This whole file is the "global" game init,
@@ -104,7 +104,6 @@ Reset::
 	ldh [hOAMHigh], a
 
 	; `Intro`'s bank has already been loaded earlier
-	rst $38
 	jp Intro
 
 SECTION "OAM DMA routine", ROMX
@@ -144,9 +143,9 @@ wShadowOAM::
 	ds NB_SPRITES * 4
 
 
-; If using banked WRAM, then you will get an error; replace $E000 with $D000
+FAIL "If not using banked WRAM, then replace $D000 with $E000 and delete this line"
 ; This ensures that the stack is at the very end of WRAM
-SECTION "Stack", WRAM0[$E000 - STACK_SIZE]
+SECTION "Stack", WRAM0[$D000 - STACK_SIZE]
 
 	ds STACK_SIZE
 wStackBottom:

--- a/src/intro.asm
+++ b/src/intro.asm
@@ -2,4 +2,8 @@
 SECTION "Intro", ROMX
 
 Intro::
+; Remove this line
+	rst $38
+
+; Put your code here!
 	jr @


### PR DESCRIPTION
Fixes #4 and #5

Change README to give advice on where to start, and properly comment the crash handler invocation to ensure it's not missed.