### PR TITLE
Avoid creating intermediate .mk files

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -13,7 +13,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          # - windows-latest (The build is flaky there because of #1, unfortunately.)
+          - windows-latest
       fail-fast: false
     runs-on: ${{ matrix.os }}
     


### PR DESCRIPTION
My goal here is to make issue #1 a moot point, since no file timestamps will be involved.

Instead of storing the `rgbasm -M` output in a .mk file for each .o and then `include`ing all those .mk files in the Makefile, this just directly dumps the `rgbasm -M` output into the Makefile.

This is similar to how [pokecrystal's Makefile](https://github.com/pret/pokecrystal/blob/master/Makefile) works, using `scan_includes` instead of `rgbasm -M`.

It has to work around the fact that `$(shell)` unavoidably turns newlines into spaces, by `tr`ing them into pipe characters and then `subst`ituting to undo the transformation. (The pipe `|` is highly unlikely to be in any Linux filenames, and is outright forbidden on Windows.)

I did have an issue with building this from scratch on macOS, where `make` would fail (`Error opening INCBIN file 'assets/crash_font.1bpp.pb8': No such file or directory`) but running it again would succeed. This was because `rgbasm -M` was not outputting the `assets/crash_font.1bpp.pb8` target unless `assets/crash_font.1bpp.pb8.size` existed. I think that's a bug with RGBDS; see https://github.com/gbdev/rgbds/issues/903#issuecomment-2855534584. Anyway, having .pb8.size depend on .pb8 directly fixes it too.