### PR TITLE
Use RGBDS 0.9.4

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -22,7 +22,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         mkdir rgbds
-        curl -L https://github.com/gbdev/rgbds/releases/download/v0.9.1/rgbds-0.9.1-linux-x86_64.tar.xz | tar xJC rgbds
+        curl -L https://github.com/gbdev/rgbds/releases/download/v0.9.4/rgbds-linux-x86_64.tar.xz | tar xJC rgbds
         cd rgbds
         sudo ./install.sh
     - name: Install RGBDS and Make (macOS)
@@ -35,8 +35,8 @@ jobs:
       shell: bash
       run: | # RGBDS needs to go into that directory to be picked up by Make as `rgb*` instead of needing `rgb*.exe`.
         mkdir rgbds
-        curl -LOJ https://github.com/gbdev/rgbds/releases/download/v0.9.1/rgbds-0.9.1-win64.zip
-        unzip -d /c/mingw64/bin rgbds-0.9.1-win64.zip
+        curl -LOJ https://github.com/gbdev/rgbds/releases/download/v0.9.4/rgbds-win64.zip
+        unzip -d /c/mingw64/bin rgbds-win64.zip
     - name: Checkout
       uses: actions/checkout@v4
       with:

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,9 @@ RGBFIX  := ${RGBDS}rgbfix
 RGBGFX  := ${RGBDS}rgbgfx
 
 INCDIRS  := src/ include/
-WARNINGS := all extra
-ASFLAGS  = -p ${PADVALUE} $(addprefix -I,${INCDIRS}) $(addprefix -W,${WARNINGS})
-LDFLAGS  = -p ${PADVALUE}
-FIXFLAGS = -p ${PADVALUE} -i "${GAMEID}" -k "${LICENSEE}" -l ${OLDLIC} -m ${MBC} -n ${VERSION} -r ${SRAMSIZE} -t ${TITLE}
+ASFLAGS  = -p ${PADVALUE} $(addprefix -I,${INCDIRS}) -Wextra
+LDFLAGS  = -p ${PADVALUE} -Wall
+FIXFLAGS = -p ${PADVALUE} -i "${GAMEID}" -k "${LICENSEE}" -l ${OLDLIC} -m ${MBC} -n ${VERSION} -r ${SRAMSIZE} -t ${TITLE} -Wall
 
 ROM = bin/${ROMNAME}.${ROMEXT}
 SRCS := $(call rwildcard,src,*.asm)

--- a/src/lib/crash_handler.asm
+++ b/src/lib/crash_handler.asm
@@ -24,7 +24,7 @@ Crash:: align 16, $38
 	newcharmap crash_handler
 def CHARS equs "0123456789ABCDEF-GHIJKLMNOPQR:SUVWXYZabcdefghijklmnopqrTstuvwxyz! "
 FOR CHAR, STRLEN("{CHARS}")
-	charmap STRSUB("{CHARS}", CHAR + 1, 1), CHAR
+	charmap STRSLICE("{CHARS}", CHAR, CHAR + 1), CHAR
 ENDR
 
 def HEADER_WIDTH EQU 19
@@ -183,11 +183,11 @@ INCLUDE "assets/crash_font.1bpp.pb8.size"
 	ld de, .header
 	ld b, HEADER_HEIGHT
 .writeHeaderLine
-	ld a, " "
+	ld a, ' '
 	ld [hli], a
 	ld c, HEADER_WIDTH
 	rst MemcpySmall
-	ld a, " "
+	ld a, ' '
 	ld [hli], a
 	ld a, l
 	add a, SCRN_VX_B - HEADER_WIDTH - 2
@@ -196,7 +196,7 @@ INCLUDE "assets/crash_font.1bpp.pb8.size"
 	jr nz, .writeHeaderLine
 
 	; Blank line.
-	ld a, " "
+	ld a, ' '
 	ld c, SCRN_X_B + 1
 	rst MemsetSmall
 
@@ -210,7 +210,7 @@ INCLUDE "assets/crash_font.1bpp.pb8.size"
 	rst MemcpySmall
 	ldh a, [hConsoleType]
 	call .printHexA
-	ld a, " "
+	ld a, ' '
 	ld [hli], a
 	ld [hli], a
 	ld [hli], a
@@ -225,7 +225,7 @@ INCLUDE "assets/crash_font.1bpp.pb8.size"
 	rst MemcpySmall
 	pop bc
 	call .printHexBC
-	ld a, " "
+	ld a, ' '
 	ld [hli], a
 	ld [hli], a
 	ld [hli], a
@@ -263,18 +263,18 @@ INCLUDE "assets/crash_font.1bpp.pb8.size"
 	rst MemcpySmall
 	ld a, [wCrashIE]
 	call .printHexA
-	ld [hl], " "
+	ld [hl], ' '
 
 	ld l, LOW(vCrashDumpScreen.row15)
 	ld c, 7
 	rst MemcpySmall
 .writeBank
-	ld a, " "
+	ld a, ' '
 	ld [hli], a
 	ld a, [de]
 	inc de
 	ld [hli], a
-	cp " "
+	cp ' '
 	jr z, .banksDone
 	ld a, [de]
 	inc de
@@ -303,7 +303,7 @@ INCLUDE "assets/crash_font.1bpp.pb8.size"
 	ld [hli], a
 	dec c
 	jr nz, .writeBuildDate
-	ld a, " "
+	ld a, ' '
 	ld [hli], a
 
 	ld l, LOW(vCrashDumpScreen.row17)
@@ -481,7 +481,7 @@ ENDR
 	ld b, d
 	ld c, e
 	call .printHexBC
-	ld a, " "
+	ld a, ' '
 	ld [hli], a
 	ld [hli], a
 	ld a, e
@@ -494,7 +494,7 @@ ENDR
 	ld a, l
 	add a, SCRN_VX_B - SCRN_X_B - 1
 	ld l, a
-	ld a, " "
+	ld a, ' '
 	ld [hli], a
 .writeDumpWord
 	ld a, [de]
@@ -503,7 +503,7 @@ ENDR
 	ld a, [de]
 	inc de
 	call .printHexA
-	ld a, " "
+	ld a, ' '
 	ld [hli], a
 	bit 4, l
 	jr nz, .writeDumpWord


### PR DESCRIPTION
RGBDS 0.9.4 introduced numeric `'c'`haracter constants, and RGBDS 1.0.0 will deprecate treating strings as numbers. This change will build with 0.9.4 and with 1.0.0, without deprecation warnings.

RGBDS 0.9.4 also introduced `-W`arning flags for programs besides RGBASM, so I've added those (although not at the `everything` level) to the Makefile.